### PR TITLE
chore(quality): create values.yaml files per chart and environment

### DIFF
--- a/.github/workflows/deploy_inflection_ru.yaml
+++ b/.github/workflows/deploy_inflection_ru.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
     paths:
-      - 'environments/*/core.values.yaml'
       - 'charts/inflection-ru/**'
       - 'sidecars/inflection-ru/**'
       - '.github/workflows/build_sidecar.yml'

--- a/.github/workflows/deploy_morphology.yaml
+++ b/.github/workflows/deploy_morphology.yaml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - charts/morphology/**
-      - environments/*/core.values.yaml
+      - environments/*/morphology.values.yaml
       - sidecars/morphology/**
       - .github/workflows/build_sidecar.yml
       - .github/workflows/deploy_morphology.yaml
@@ -56,6 +56,6 @@ jobs:
       - name: deploy
         run: |
           helm upgrade --install --namespace grammr \
-            --values ./environments/prod/core.values.yaml --wait --timeout 600s \
+            --values ./environments/prod/morphology.values.yaml --wait --timeout 600s \
             morphology ./charts/morphology
         

--- a/.github/workflows/deploy_morphology_serverless.yaml
+++ b/.github/workflows/deploy_morphology_serverless.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'environments/*/core.values.yaml'
+      - 'environments/*/morphology.values.yaml'
       - 'sidecars/morphology/**'
       - 'terraform/**'
       - '.github/workflows/deploy_morphology_serverless.yaml'

--- a/.github/workflows/deploy_multi_inflection.yaml
+++ b/.github/workflows/deploy_multi_inflection.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'environments/*/core.values.yaml'
+      - 'environments/*/multi-inflection.values.yaml'
       - 'charts/multi-inflection/**'
       - 'sidecars/multi-inflection/**'
       - '.github/workflows/build_sidecar.yml'
@@ -55,7 +55,7 @@ jobs:
           helm upgrade --install \
             --namespace grammr-dev --create-namespace \
             --wait --timeout 600s \
-            --values ./environments/dev/core.values.yaml \
+            --values ./environments/dev/multi-inflection.values.yaml \
             multi-inflection ./charts/multi-inflection
 
   deploy-prod:
@@ -72,6 +72,6 @@ jobs:
           helm upgrade --install \
             --namespace grammr --create-namespace \
             --wait --timeout 600s \
-            --values ./environments/prod/core.values.yaml \
+            --values ./environments/prod/multi-inflection.values.yaml \
             multi-inflection ./charts/multi-inflection
         

--- a/charts/grammr/templates/NOTES.txt
+++ b/charts/grammr/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "lingolift-core.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "grammr-core.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "lingolift-core.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "lingolift-core.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "grammr-core.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "grammr-core.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "lingolift-core.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "grammr-core.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT

--- a/charts/grammr/templates/_helpers.tpl
+++ b/charts/grammr/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "lingolift-core.name" -}}
+{{- define "grammr-core.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "lingolift-core.fullname" -}}
+{{- define "grammr-core.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "lingolift-core.chart" -}}
+{{- define "grammr-core.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "lingolift-core.labels" -}}
-helm.sh/chart: {{ include "lingolift-core.chart" . }}
-{{ include "lingolift-core.selectorLabels" . }}
+{{- define "grammr-core.labels" -}}
+helm.sh/chart: {{ include "grammr-core.chart" . }}
+{{ include "grammr-core.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,8 +45,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "lingolift-core.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "lingolift-core.name" . }}
+{{- define "grammr-core.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "grammr-core.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/grammr/templates/deployment.yaml
+++ b/charts/grammr/templates/deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "lingolift-core.fullname" . }}
+  name: {{ include "grammr-core.fullname" . }}
   labels:
-    {{- include "lingolift-core.labels" . | nindent 4 }}
+    {{- include "grammr-core.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "lingolift-core.selectorLabels" . | nindent 6 }}
+      {{- include "grammr-core.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -16,7 +16,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "lingolift-core.labels" . | nindent 8 }}
+        {{- include "grammr-core.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/grammr/templates/service.yaml
+++ b/charts/grammr/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "lingolift-core.fullname" . }}
+  name: {{ include "grammr-core.fullname" . }}
   labels:
-    {{- include "lingolift-core.labels" . | nindent 4 }}
+    {{- include "grammr-core.labels" . | nindent 4 }}
   annotations:
     prometheus.io/path: /actuator/prometheus
     prometheus.io/port: "8080"
@@ -16,4 +16,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "lingolift-core.selectorLabels" . | nindent 4 }}
+    {{- include "grammr-core.selectorLabels" . | nindent 4 }}

--- a/charts/grammr/values.yaml
+++ b/charts/grammr/values.yaml
@@ -1,4 +1,4 @@
-# Default values for lingolift-core.
+# Default values for grammr-core.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/charts/inflection-ru/values.yaml
+++ b/charts/inflection-ru/values.yaml
@@ -20,24 +20,24 @@ serviceAccount:
   # Automatically mount a ServiceAccount's API credentials?
   automount: true
   # Annotations to add to the service account
-  annotations: {}
+  annotations: { }
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations: {}
-podLabels: {}
+podAnnotations: { }
+podLabels: { }
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext: { }
+# fsGroup: 2000
 
-securityContext: {}
+securityContext: { }
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
-  # runAsUser: 1000
+# runAsUser: 1000
 
 service:
   type: ClusterIP
@@ -46,30 +46,26 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations: { }
     # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: []
+  tls: [ ]
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 96Mi
 
 livenessProbe:
   httpGet:
@@ -90,20 +86,20 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 # Additional volumes on the output Deployment definition.
-volumes: []
+volumes: [ ]
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
+volumeMounts: [ ]
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-nodeSelector: {}
+nodeSelector: { }
 
-tolerations: []
+tolerations: [ ]
 
-affinity: {}
+affinity: { }

--- a/charts/multi-inflection/README.md
+++ b/charts/multi-inflection/README.md
@@ -1,1 +1,7 @@
 # multi-inflection
+
+This chart utilizes a Docker image built on top of the `verbecc` Python library to provide
+conjugations for Italian, French, Spanish, Portuguese and Romanian.
+
+It will spawn Pods/Services listening on port 8000 for each language supplied in the `languageCodes`
+array. Allowed values for the `languageCodes` array are: `it`, `fr`, `es`, `pt`, `ro`.

--- a/charts/multi-inflection/templates/deployment.yaml
+++ b/charts/multi-inflection/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{ range $languageCode := $.Values.multiInflection.languageCodes }}
+{{ range $languageCode := $.Values.languageCodes }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/multi-inflection/templates/service.yaml
+++ b/charts/multi-inflection/templates/service.yaml
@@ -1,4 +1,4 @@
-{{ range $languageCode := $.Values.multiInflection.languageCodes }}
+{{ range $languageCode := $.Values.languageCodes }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/multi-inflection/values.yaml
+++ b/charts/multi-inflection/values.yaml
@@ -13,8 +13,8 @@ image:
 nameOverride: ""
 fullnameOverride: "inflection"
 
-multiInflection:
-  languageCodes: []
+# Allowed values: RU, IT, ES, PT, RO
+languageCodes: []
 
 podAnnotations: {}
 podLabels: {}

--- a/environments/dev/core.values.yaml
+++ b/environments/dev/core.values.yaml
@@ -1,5 +1,6 @@
-allowedOrigin: "https://grmmr.vercel.app"
+allowedOrigin: "https://grammr.app"
 environment: dev
+fullnameOverride: "core"
 
 ingress:
   enabled: true
@@ -9,7 +10,6 @@ ingress:
 
 languages:
   - code: ru
-    model: ru_core_news_lg
     morphology:
       enabled: true
       uri: "https://b4l7c733qf.execute-api.eu-central-1.amazonaws.com/dev/morphology-ru"
@@ -17,21 +17,18 @@ languages:
       enabled: true
       uri: "http://inflection-ru.grammr-dev.svc.cluster.local:8000/inflect"
   - code: de
-    model: de_core_news_lg
     morphology:
       enabled: true
       uri: "https://b4l7c733qf.execute-api.eu-central-1.amazonaws.com/dev/morphology-de"
     inflection:
       enabled: false
   - code: en
-    model: en_core_web_lg
     morphology:
       enabled: true
       uri: "https://b4l7c733qf.execute-api.eu-central-1.amazonaws.com/dev/morphology-en"
     inflection:
       enabled: false
   - code: es
-    model: es_core_news_lg
     morphology:
       enabled: true
       uri: "https://b4l7c733qf.execute-api.eu-central-1.amazonaws.com/dev/morphology-es"
@@ -39,5 +36,3 @@ languages:
       enabled: true
       uri: "http://inflection-es.grammr-dev.svc.cluster.local:8000/inflect"
 
-multiInflection:
-  languageCodes: ["es"]

--- a/environments/dev/morphology.values.yaml
+++ b/environments/dev/morphology.values.yaml
@@ -1,0 +1,9 @@
+languages:
+  - code: ru
+    model: ru_core_news_lg
+  - code: de
+    model: de_core_news_lg
+  - code: en
+    model: en_core_web_lg
+  - code: es
+    model: es_core_news_lg

--- a/environments/dev/multi-inflection.values.yaml
+++ b/environments/dev/multi-inflection.values.yaml
@@ -1,0 +1,9 @@
+languageCodes: [ "es" ]
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/environments/prod/core.values.yaml
+++ b/environments/prod/core.values.yaml
@@ -1,4 +1,6 @@
 environment: prod
+allowedOrigin: "https://grammr.app"
+fullnameOverride: "core"
 
 ingress:
   enabled: true
@@ -8,7 +10,6 @@ ingress:
 
 languages:
   - code: ru
-    model: ru_core_news_lg
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-ru"
@@ -16,21 +17,18 @@ languages:
       enabled: true
       uri: "http://inflection-ru.grammr.svc.cluster.local:8000/inflect"
   - code: de
-    model: de_core_news_lg
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-de"
     inflection:
       enabled: false
   - code: en
-    model: en_core_web_lg
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-en"
     inflection:
       enabled: false
   - code: it
-    model: it_core_news_lg
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-it"
@@ -38,7 +36,6 @@ languages:
       enabled: true
       uri: "http://inflection-it.grammr.svc.cluster.local:8000/inflect"
   - code: es
-    model: es_core_news_lg
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-es"
@@ -46,7 +43,6 @@ languages:
       enabled: true
       uri: "http://inflection-es.grammr.svc.cluster.local:8000/inflect"
   - code: pt
-    model: pt_core_news_md
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-pt"
@@ -54,15 +50,9 @@ languages:
       enabled: true
       uri: "http://inflection-pt.grammr.svc.cluster.local:8000/inflect"
   - code: fr
-    model: fr_core_news_lg
     morphology:
       enabled: true
       uri: "https://xqybdr4e07.execute-api.eu-central-1.amazonaws.com/prod/morphology-fr"
     inflection:
       enabled: true
       uri: "http://inflection-fr.grammr.svc.cluster.local:8000/inflect"
-
-multiInflection:
-  languageCodes: ["it", "es", "pt", "fr"]
-
-allowedOrigin: "https://grmmr.vercel.app"

--- a/environments/prod/morphology.values.yaml
+++ b/environments/prod/morphology.values.yaml
@@ -1,0 +1,15 @@
+languages:
+  - code: ru
+    model: ru_core_news_lg
+  - code: de
+    model: de_core_news_lg
+  - code: en
+    model: en_core_web_lg
+  - code: es
+    model: es_core_news_lg
+  - code: fr
+    model: fr_core_news_lg
+  - code: it
+    model: it_core_news_lg
+  - code: pt
+    model: pt_core_news_lg

--- a/environments/prod/multi-inflection.values.yaml
+++ b/environments/prod/multi-inflection.values.yaml
@@ -1,0 +1,9 @@
+languageCodes: ["it", "es", "pt", "fr"]
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi

--- a/terraform/application/local.tf
+++ b/terraform/application/local.tf
@@ -1,6 +1,5 @@
 locals {
-  config                = yamldecode(file("${path.module}/../../environments/${var.environment}/core.values.yaml"))
-  create_ecr_repository = var.environment == "dev"
+  config                = yamldecode(file("${path.module}/../../environments/${var.environment}/morphology.values.yaml"))
 
   languages_map = {
     for lang in local.config.languages : lang.code => lang


### PR DESCRIPTION
- Add: `morphology.values.yaml` for the serverless morphology functions
- Add: `multi-inflection.values.yaml` for the multi-inflection chart
- Add: resource limits for all services currently running within Kubernetes
- Change: The `fullnameOverride` from `grammr-core` to `core` (with the resulting internal DNS being `core.grammr.svc.cluster.local`)